### PR TITLE
Update for RHEL/CentOS 8 support

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,7 +4,10 @@ gitlab_package: gitlab-ce
 gitlab_package_dependencies:
   - curl
   - ca-certificates
-  - policycoreutils-python
+  # CentOS/RHEL 7
+  # - policycoreutils-python
+  # CentOS/RHEL 8
+  - policycoreutils
   - openssh-server
   - cronie
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,9 +4,6 @@ gitlab_package: gitlab-ce
 gitlab_package_dependencies:
   - curl
   - ca-certificates
-  # CentOS/RHEL 7
-  # - policycoreutils-python
-  # CentOS/RHEL 8
   - policycoreutils
   - openssh-server
   - cronie


### PR DESCRIPTION
- Change GitLab's dependency from ```policycoreutils-python``` to ```policycoreutils``` for support RHEL/CentOS 8