### PR TITLE
support gitlab-ee install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,3 +41,6 @@ gitlab_config_backup_path: /var/opt/gitlab/backups
 # backward compatibility
 gitlab_search_config_paths: []
 gitlab_host_config_file_path: "{{ gitlab_host_config_path | default(inventory_hostname) }}/gitlab.rb.j2"
+
+# select Gitlab Edition (ce/ee)
+gitlab_edition: ce

--- a/tasks/gitlab_install.yml
+++ b/tasks/gitlab_install.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install Gitlab CE
+- name: Install Gitlab
   package:
     name: "{{ gitlab_package }}"
     state: present

--- a/tasks/gitlab_pre.yml
+++ b/tasks/gitlab_pre.yml
@@ -36,7 +36,7 @@
 
 - meta: flush_handlers
 
-- name: Run script to check system and add repository for GitLab CE
+- name: Run script to check system and add repository for GitLab
   shell: "curl -L -s {{ gitlab_script_url }} | bash"
   args:
     # Not to warn about using get_url

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,11 +1,19 @@
 ---
-gitlab_package: gitlab-ce
+package_url_map:
+  ce: gitlab-ce
+  ee: gitlab-ee
+
+gitlab_package: "{{ package_url_map[gitlab_edition] }}"
 
 gitlab_package_dependencies:
   - curl
   - ca-certificates
   - openssh-server
 
-gitlab_script_url: https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.deb.sh
+script_url_map:
+  ce: https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.deb.sh
+  ee: https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh
+
+gitlab_script_url: "{{ script_url_map[gitlab_edition] }}"
 
 gitlab_ssh_service_name: ssh


### PR DESCRIPTION
Support Gitlab Enterprise Edition install by override gitlab_edition variable from the ansible-playbook
- default/main.yml add variable gitlab_edition to let users choose Gitlab edition
- tasks/* edit jobs name by removing "CE" from jobs name.
- vars/Debian add variable package_url_map that stores package name for Gitlab-CE and Gitlab-EE and add variable  script_url_map that stores script URL for Gitlab-CE and Gitlab-EE